### PR TITLE
EVA-4164 - Add test to check that pre-existing project does not need a taxonomy

### DIFF
--- a/components/eva_submission_ws/Dockerfile
+++ b/components/eva_submission_ws/Dockerfile
@@ -12,7 +12,8 @@ RUN cp -avT /usr/local/tomcat/webapps.dist/manager /usr/local/tomcat/webapps/man
 WORKDIR /usr/local/software
 
 # deploy eva-submission-ws
-RUN git clone https://github.com/EBIvariation/eva-submission-ws.git
+#TODO: revert back before merge
+RUN git clone -b human_data_check --single-branch https://github.com/tcezard/eva-submission-ws.git
 RUN mvn package -s /root/maven-settings.xml -f eva-submission-ws/pom.xml -P docker -DskipTests
 RUN cp eva-submission-ws/target/eva-submission-ws-*.war.original /usr/local/tomcat/webapps/eva#webservices#submission-ws.war
 

--- a/tests/components/eva_sub_cli/test_eva_sub_cli.py
+++ b/tests/components/eva_sub_cli/test_eva_sub_cli.py
@@ -48,9 +48,9 @@ class TestEvaSubCli(TestWithDockerCompose):
                 file_path = os.path.join(directory, file)
                 copy_files_to_container(self.container_name, self.container_submission_dir, file_path)
 
-    def get_validation_json_metadata_existing_project(self):
+    def get_validation_json_metadata_existing_project(self, project_accession):
         json_metadata = self.get_validation_json_metadata()
-        json_metadata['project'] = {'projectAccession': 'PRJEB12770'}
+        json_metadata['project'] = {'projectAccession': project_accession}
         return json_metadata
 
     def get_validation_json_metadata_with_non_vcf_file(self):

--- a/tests/components/eva_sub_cli/test_eva_sub_cli_submission.py
+++ b/tests/components/eva_sub_cli/test_eva_sub_cli_submission.py
@@ -73,8 +73,36 @@ class TestEvaSubCliSubmission(TestEvaSubCli):
         # assert submission result
         self.assert_submission_results(webin_account, webin_email, existing_project=True)
 
-    def get_submission_json_metadata(self):
-        json_metadata = self.get_validation_json_metadata()
+    @log_on_failure
+    def test_submission_to_existing_project_notaxid(self):
+        # create metadata json file and copy to container
+        sub_metadata = self.get_submission_json_metadata_existing_project_no_taxid_biosample()
+        with open(self.metadata_json, 'w') as open_metadata:
+            json.dump(sub_metadata, open_metadata)
+        copy_files_to_container(self.container_name, self.container_submission_dir, self.metadata_json)
+
+        # copy validation success config file for the test submission
+        validation_passed_config_file = os.path.join(self.resources_directory, 'validation_passed_config_file',
+                                                     '.eva_sub_cli_config.yml')
+        copy_files_to_container(self.container_name, self.container_submission_dir,
+                                validation_passed_config_file)
+
+        webin_account, webin_email, webin_password = self.webin_test_user.get_webin_submission_account_details()
+
+        validation_cmd = (
+            f"docker exec {self.container_name} eva-sub-cli.py --executor=NATIVE --tasks=SUBMIT "
+            f"--submission_dir {self.container_submission_dir} "
+            f"--metadata_json {os.path.join(self.container_submission_dir, os.path.basename(self.metadata_json))} "
+            f"--username {webin_account} --password {webin_password}"
+        )
+        # Run submission from command line
+        run_quiet_command("submit through eva-sub-cli", validation_cmd, log_error_stream_to_output=True)
+
+        # assert submission result
+        self.assert_submission_results(webin_account, webin_email, existing_project=True)
+
+
+    def add_files(self, json_metadata):
         json_metadata['files'] = [
             {
                 "analysisAlias": "AA",
@@ -84,13 +112,24 @@ class TestEvaSubCliSubmission(TestEvaSubCli):
         ]
         return json_metadata
 
+    def get_submission_json_metadata(self):
+        json_metadata = self.get_validation_json_metadata()
+        json_metadata = self.add_files(json_metadata)
+        return json_metadata
+
     def get_submission_json_metadata_existing_project(self):
         json_metadata = self.get_validation_json_metadata_existing_project()
-        json_metadata['files'] = [
+        json_metadata = self.add_files(json_metadata)
+        return json_metadata
+
+    def get_submission_json_metadata_existing_project_no_taxid_biosample(self):
+        json_metadata = self.get_validation_json_metadata_existing_project()
+        json_metadata = self.add_files(json_metadata)
+        json_metadata['sample'] =  [
             {
-                "analysisAlias": "AA",
-                "fileName": "input_passed.vcf",
-                "fileSize": 45050
+                "analysisAlias": ["AA"],
+                "sampleInVCF": "HG00096",
+                "bioSampleAccession": "SAMN04396628"
             }
         ]
         return json_metadata

--- a/tests/components/eva_sub_cli/test_eva_sub_cli_submission.py
+++ b/tests/components/eva_sub_cli/test_eva_sub_cli_submission.py
@@ -118,12 +118,12 @@ class TestEvaSubCliSubmission(TestEvaSubCli):
         return json_metadata
 
     def get_submission_json_metadata_existing_project(self):
-        json_metadata = self.get_validation_json_metadata_existing_project()
+        json_metadata = self.get_validation_json_metadata_existing_project('PRJEB12770')
         json_metadata = self.add_files(json_metadata)
         return json_metadata
 
     def get_submission_json_metadata_existing_project_no_taxid_biosample(self):
-        json_metadata = self.get_validation_json_metadata_existing_project()
+        json_metadata = self.get_validation_json_metadata_existing_project('PRJEB90338')
         json_metadata = self.add_files(json_metadata)
         json_metadata['sample'] =  [
             {

--- a/tests/components/eva_sub_cli/test_eva_sub_cli_validation.py
+++ b/tests/components/eva_sub_cli/test_eva_sub_cli_validation.py
@@ -121,7 +121,7 @@ class TestEvaSubCliValidation(TestEvaSubCli):
     @log_on_failure
     def test_docker_validator_with_json_existing_project(self):
         # create metadata json file and copy to container
-        sub_metadata = self.get_validation_json_metadata_existing_project()
+        sub_metadata = self.get_validation_json_metadata_existing_project('PRJEB12770')
         with open(self.metadata_json, 'w') as open_metadata:
             json.dump(sub_metadata, open_metadata)
         copy_files_to_container(self.container_name, self.container_submission_dir, self.metadata_json)


### PR DESCRIPTION
New test [fails](https://github.com/EBIvariation/eva-integration-tests/actions/runs/25117399016/job/73608346276#step:5:166) before and [pass](https://github.com/EBIvariation/eva-integration-tests/actions/runs/25124353294/job/73675579393) after using the feature branch for eva-submission-ws