### PR TITLE
EVA-4226: Check tests still pass on branch

### DIFF
--- a/components/eva_assembly_ingestion/install_repo.sh
+++ b/components/eva_assembly_ingestion/install_repo.sh
@@ -7,10 +7,6 @@ if [[ -z "$SOURCE_GITHUB_REPOSITORY" ]] ; then SOURCE_GITHUB_REPOSITORY=EBIvaria
 if [[ -z "$SOURCE_GITHUB_REF" ]] ; then SOURCE_GITHUB_REF=main ; fi
 if [[ -n "$SOURCE_GITHUB_SHA" ]] ; then SOURCE_GITHUB_REF=$SOURCE_GITHUB_SHA ; fi
 
-# TODO revert before merge
-SOURCE_GITHUB_REPOSITORY=apriltuesday/eva-assembly-ingestion
-SOURCE_GITHUB_REF=EVA-4226
-
 echo "Clone https://github.com/${SOURCE_GITHUB_REPOSITORY}.git"
 
 git clone https://github.com/${SOURCE_GITHUB_REPOSITORY}.git eva-assembly-ingestion

--- a/components/eva_assembly_ingestion/install_repo.sh
+++ b/components/eva_assembly_ingestion/install_repo.sh
@@ -7,6 +7,10 @@ if [[ -z "$SOURCE_GITHUB_REPOSITORY" ]] ; then SOURCE_GITHUB_REPOSITORY=EBIvaria
 if [[ -z "$SOURCE_GITHUB_REF" ]] ; then SOURCE_GITHUB_REF=main ; fi
 if [[ -n "$SOURCE_GITHUB_SHA" ]] ; then SOURCE_GITHUB_REF=$SOURCE_GITHUB_SHA ; fi
 
+# TODO revert before merge
+SOURCE_GITHUB_REPOSITORY=apriltuesday/eva-assembly-ingestion
+SOURCE_GITHUB_REF=EVA-4226
+
 echo "Clone https://github.com/${SOURCE_GITHUB_REPOSITORY}.git"
 
 git clone https://github.com/${SOURCE_GITHUB_REPOSITORY}.git eva-assembly-ingestion

--- a/components/eva_assembly_ingestion/nextflow.config
+++ b/components/eva_assembly_ingestion/nextflow.config
@@ -1,4 +1,6 @@
 process {
+    shell = ['bash', '-euo', 'pipefail']
+
     process.ext.base_memory = 2.GB
     process.ext.base_time = 1.hours
     memory = { task.ext.base_memory * task.attempt }


### PR DESCRIPTION
Not to merge but to demonstrate assembly ingestion tests [pass on the branch](https://github.com/EBIvariation/eva-integration-tests/actions/runs/30442421937/job/90547894090), and [fail on main](https://github.com/EBIvariation/eva-integration-tests/actions/runs/30444065907/job/90550101119) when `-o pipefail` is set in the config.